### PR TITLE
Fix clock sample

### DIFF
--- a/samples/simple-clock/app/src/commonMain/kotlin/com.eygraber.cure.samples.simple_clock/clock/ClockCompositor.kt
+++ b/samples/simple-clock/app/src/commonMain/kotlin/com.eygraber.cure.samples.simple_clock/clock/ClockCompositor.kt
@@ -1,18 +1,13 @@
 package com.eygraber.cure.samples.simple_clock.clock
 
 import com.eygraber.cure.Compositor
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
 
-class ClockCompositor(
-  private val currentState: StateFlow<ClockState>
-) : Compositor<ClockState, ClockEvent> {
+class ClockCompositor : Compositor<ClockState, ClockEvent> {
   private val clockUseCase = ClockUseCase()
 
   override val stateFlow =
     clockUseCase
       .secondsTick()
       .map { ClockState(it) }
-      .onStart { emit(currentState.value) }
 }

--- a/samples/simple-clock/app/src/commonMain/kotlin/com.eygraber.cure.samples.simple_clock/clock/ClockRenderNode.kt
+++ b/samples/simple-clock/app/src/commonMain/kotlin/com.eygraber.cure.samples.simple_clock/clock/ClockRenderNode.kt
@@ -6,7 +6,7 @@ import com.eygraber.cure.StateSerializer
 class ClockRenderNode(
   initialState: ClockState
 ) : RenderNode<ClockState, ClockEvent>(initialState) {
-  override val compositor = ClockCompositor(currentState)
+  override val compositor = ClockCompositor()
   override val renderer = ClockRenderer()
 
   companion object Factory : RenderNode.Factory<ClockState, ClockEvent> {


### PR DESCRIPTION
  - After previous refactors, the compositor doesn't need the original state since it is passed to collectAsState and emitted from there